### PR TITLE
fix(sana-sendoff): adjust manual dates in timeline

### DIFF
--- a/components/project/experimental/Timeline.tsx
+++ b/components/project/experimental/Timeline.tsx
@@ -123,7 +123,7 @@ export function ProjectTimeline({ events }: ProjectTimelineProps) {
 				</li>
 				<li>
 					<div>
-						<time dateTime="2021-10-13">{(new Date('2021-10-13')).toLocaleDateString(undefined, { ...dateStringOptions, timeZone: 'Japan' })}</time>
+						<time dateTime="2021-10-13T02:33:31Z">{(new Date('2021-10-13T02:33:31Z')).toLocaleDateString(undefined, dateStringOptions)}</time>
 						Sana achieves 200,000 YouTube subscribers.
 					</div>
 				</li>
@@ -154,7 +154,7 @@ export function ProjectTimeline({ events }: ProjectTimelineProps) {
 				</li>
 				<li>
 					<div>
-						<time dateTime="2021-11-19">{(new Date('2021-11-19')).toLocaleDateString(undefined, { ...dateStringOptions, timeZone: 'America/New_York' })}</time>
+						<time dateTime="2021-11-19T14:30:00-0400">{(new Date('2021-11-19T14:30:00-0400')).toLocaleDateString(undefined, dateStringOptions)}</time>
 						Sana appears alongside Council at Anime NYC during a special panel.
 					</div>
 				</li>
@@ -247,7 +247,7 @@ export function ProjectTimeline({ events }: ProjectTimelineProps) {
 				</li>
 				<li>
 					<div>
-						<time dateTime="2022-03-10">{(new Date('2022-03-10')).toLocaleDateString(undefined, { ...dateStringOptions, timeZone: 'Japan' })}</time>
+						<time dateTime="2022-03-10T16:04:31Z">{(new Date('2022-03-10T16:04:31Z')).toLocaleDateString(undefined, dateStringOptions)}</time>
 						Sana achieves 300,000 YouTube subscribers.
 					</div>
 				</li>
@@ -303,7 +303,7 @@ export function ProjectTimeline({ events }: ProjectTimelineProps) {
 				</li>
 				<li>
 					<div>
-						<time dateTime="2022-07-16">{(new Intl.DateTimeFormat(undefined, { ...dateStringOptions, timeZone: 'Australia/Sydney' })).formatRange(new Date('2022-07-16'), new Date('2022-07-17'))}</time>
+						<time dateTime="2022-07-16T00:00:00Z">{(new Intl.DateTimeFormat(undefined, dateStringOptions)).formatRange(new Date('2022-07-16T00:00:00Z'), new Date('2022-07-17T00:00:00Z'))}</time>
 						Sana appears at Smash Con 2022 along with Bae, doing two panels as well as a meet-and-greet with lucky fans.
 					</div>
 				</li>

--- a/components/project/experimental/Timeline.tsx
+++ b/components/project/experimental/Timeline.tsx
@@ -154,7 +154,7 @@ export function ProjectTimeline({ events }: ProjectTimelineProps) {
 				</li>
 				<li>
 					<div>
-						<time dateTime="2021-11-19T14:30:00-0400">{(new Date('2021-11-19T14:30:00-0400')).toLocaleDateString(undefined, dateStringOptions)}</time>
+						<time dateTime="2021-11-19T14:30:00-0500">{(new Date('2021-11-19T14:30:00-0500')).toLocaleDateString(undefined, dateStringOptions)}</time>
 						Sana appears alongside Council at Anime NYC during a special panel.
 					</div>
 				</li>

--- a/components/project/experimental/Timeline.tsx
+++ b/components/project/experimental/Timeline.tsx
@@ -123,7 +123,7 @@ export function ProjectTimeline({ events }: ProjectTimelineProps) {
 				</li>
 				<li>
 					<div>
-						<time dateTime="2021-10-13T02:33:31Z">{(new Date('2021-10-13T02:33:31Z')).toLocaleDateString(undefined, dateStringOptions)}</time>
+						<time dateTime="2021-10-13T02:05:45Z">{(new Date('2021-10-13T02:05:45Z')).toLocaleDateString(undefined, dateStringOptions)}</time>
 						Sana achieves 200,000 YouTube subscribers.
 					</div>
 				</li>
@@ -247,7 +247,7 @@ export function ProjectTimeline({ events }: ProjectTimelineProps) {
 				</li>
 				<li>
 					<div>
-						<time dateTime="2022-03-10T16:04:31Z">{(new Date('2022-03-10T16:04:31Z')).toLocaleDateString(undefined, dateStringOptions)}</time>
+						<time dateTime="2022-03-10T14:32:01Z">{(new Date('2022-03-10T14:32:01Z')).toLocaleDateString(undefined, dateStringOptions)}</time>
 						Sana achieves 300,000 YouTube subscribers.
 					</div>
 				</li>


### PR DESCRIPTION
https://github.com/GoldElysium/hef-website/pull/286/commits/089ef8e686e36bd7fed3edf6e59dfc627c6ac621 is not totes correct.

We want all dates to be displayed in user's local timezone, but that code coerces midnight UTC dates to different fixed timezones instead.

Considering the intention of fix being in constructing timestamp more precisely, here are more accurate dates.

- 200k subs milestone is sourced from [holo_analytics tweet](https://twitter.com/holo_analytics/status/1448107661879242752)
- 300k subs milestone [same logic](https://twitter.com/holo_analytics/status/1501928868122292224)
- Anime NYC debut: `14:30:00-0400` (2:30 pm in New York) according to [this tweet](https://twitter.com/animenyc/status/1461718498795790336)
- Smash Con: exact start date comes from [the tweet](https://twitter.com/smashcon/status/1548095114098003979) rounded down, exact end date is exactly +1 day for simplicity (otherwise in many timezones it would show 3-day range which is confusing)

/cc @waylaidwanderer