### PR TITLE
Various fixes to music; theming

### DIFF
--- a/components/DarkModeToggle.tsx
+++ b/components/DarkModeToggle.tsx
@@ -3,12 +3,15 @@ import DarkModeContext from '../contexts/DarkModeContext';
 export default function DarkModeToggle() {
 	return (
 		<DarkModeContext.Consumer>
-			{({ darkMode, toggleDarkMode }) => (
+			{({ darkMode, saveDarkMode, toggleDarkMode }) => (
 				<div className="flex flex-nowrap align-middle items-center">
 					<label className="switch ml-6">
 						<input
 							type="checkbox"
-							onChange={() => toggleDarkMode()}
+							onChange={() => {
+								toggleDarkMode();
+								saveDarkMode();
+							}}
 							checked={darkMode}
 						/>
 						<span className={darkMode ? 'slider round bg-skin-dark-primary-1' : 'slider round bg-skin-background-1'} />

--- a/components/project/experimental/BackgroundMusic.tsx
+++ b/components/project/experimental/BackgroundMusic.tsx
@@ -1,8 +1,11 @@
-import { useCallback, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import Button from '@material-ui/core/Button';
 import Card from '@material-ui/core/Card';
 import Grid from '@material-ui/core/Grid';
+import Icon from '@material-ui/core/Icon';
 import IconButton from '@material-ui/core/IconButton';
 import Slider from '@material-ui/core/Slider';
+import ErrorIcon from '@material-ui/icons/Error';
 import VolumeOffIcon from '@material-ui/icons/VolumeOff';
 import VolumeUpIcon from '@material-ui/icons/VolumeUp';
 
@@ -13,39 +16,141 @@ export interface ProjectBackgroundMusicProps {
 // TODO: Themes?
 
 export function ProjectBackgroundMusic({ backgroundMusic }: ProjectBackgroundMusicProps) {
-	const [muted, setMuted] = useState(false); 
+	const audio = useRef<HTMLAudioElement | null>(null);
+
+	const [autoplayed, setAutoplayed] = useState(false);
+	const [blocked, setBlocked] = useState(false);
+	const [hidden, setHidden] = useState(false);
+	const [muted, setMuted] = useState(true); 
 	const [volume, setVolume] = useState(0.125);
 
-	const audio = useCallback((audioDeez: HTMLAudioElement | null) => {
-		if (audioDeez != null) {
-			audioDeez.volume = volume;
+	useEffect(() => {
+		const audioSnapshot = audio.current;
+
+		if (audioSnapshot != null) {
+			audioSnapshot.volume = volume;
 		}
-	}, [ volume ]);
+	}, [ audio, volume ]);
+
+	useEffect(() => {
+		if (blocked) return;
+		if (autoplayed) return;
+
+		const audioSnapshot = audio.current;
+
+		if (audioSnapshot != null) {
+			(async () => {
+				const play = () => new Promise((resolve) => {
+					const played = audioSnapshot.play();
+          
+					// Node uses an object for this, browsers use a number.
+					let timeout: any;
+
+					const cleanupResolve = (value: boolean) => {
+						clearTimeout(timeout);
+						resolve(value);
+					};
+
+					timeout = setTimeout(() => cleanupResolve(false), 250);
+
+					if (played != null) {
+						played
+							.then(() => cleanupResolve(true))
+							.catch(() => cleanupResolve(false));
+					} else {
+						resolve(true);
+					}
+				});
+
+				const autoPlaying = await play();
+
+				if (!autoPlaying) {
+					let clickEventListener: () => Promise<void>;
+					let hoverEventListener: () => Promise<void>;
+
+					clickEventListener = async () => {
+						const nowAutoPlaying = await play();
+
+						if (!nowAutoPlaying) {
+							console.warn('This browser _really_ doesn\'t want us to autoplay music, even after interaction, so I guess we just won\'t have any music then.');
+							setBlocked(true);
+							audioSnapshot.remove();
+						} else {
+							setAutoplayed(true);
+						}
+
+						document.body.removeEventListener('mousedown', clickEventListener);
+						document.body.removeEventListener('mouseover', hoverEventListener);
+					};
+
+					hoverEventListener = async () => {
+						const nowAutoPlaying = await play();
+
+						if (nowAutoPlaying) {
+							setAutoplayed(true);
+							document.body.removeEventListener('mousedown', clickEventListener);
+						}
+
+						document.body.removeEventListener('mouseover', hoverEventListener);
+					};
+
+					document.body.addEventListener('mousedown', clickEventListener);
+					document.body.addEventListener('mouseover', hoverEventListener);
+				}
+			})()
+				.catch(console.error);
+		}
+	}, [ audio, autoplayed, blocked ]);
+
+	if (hidden) return (<></>);
+
+	if (blocked) {
+		return (
+			<Card classes={{ root: 'fixed bottom-4 left-4 z-50 text-black dark:text-white bg-skin-background-2 dark:bg-skin-dark-background-2' }}>
+				<div className='relative w-128 h-16 flex justify-center items-center'>
+					<Icon classes={{ root: 'flex mx-4' }}>
+						<ErrorIcon/>
+					</Icon>
+					Your browser has denied audio playback
+					<Button
+						classes={{ root: 'mx-4 text-skin-primary-1 darK:text-skin-primary-1' }}
+						variant='text'
+						onClick={() => setHidden(true)}>
+						Dismiss
+					</Button>
+				</div>
+			</Card>
+		);
+	}
 
 	return (
 		<>
 			<audio
 				ref={audio}
-				autoPlay={true}
 				controls={false}
 				loop={true}
 				muted={muted}>
-				<source src={backgroundMusic} type="audio/mp3"></source>
+				<source src={backgroundMusic} type='audio/mp3'></source>
 			</audio>
-			<Card className="fixed bottom-4 left-4 z-50">
-				<div className="relative left-3 w-64 h-16 flex justify-center items-center">
+			<Card classes={{ root: 'fixed bottom-4 left-4 z-50 bg-skin-card dark:bg-skin-dark-card' }}>
+				<div className='relative left-3 w-64 h-16 flex justify-center items-center'>
 					<Grid container spacing={1}>
 						<Grid item xs={2}>
-							<IconButton onClick={() => setMuted(!muted)}>
+							<IconButton
+								classes={{ root: 'text-black dark:text-white' }}
+								onClick={() => setMuted(!muted)}>
 								{!muted && (<VolumeUpIcon/>) || (<VolumeOffIcon/>)}
 							</IconButton>
 						</Grid>
-						<Grid item xs={8} sx={{
-							display: 'flex',
-							justifyContent: 'center',
-							alignItems: 'center',
-						}}>
+						<Grid item
+							classes={{ root: 'flex justify-center items-center' }}
+							xs={8}>
 							<Slider
+								classes={{
+									rail: 'bg-skin-background-2 dark:bg-skin-dark-background-2',
+									thumb: 'bg-skin-primary-1 dark:bg-skin-dark-primary-1',
+									track: 'bg-skin-primary-1 dark:bg-skin-dark-primary-1',
+								}}
 								disabled={muted}
 								max={1}
 								min={0}

--- a/components/project/experimental/BackgroundMusic.tsx
+++ b/components/project/experimental/BackgroundMusic.tsx
@@ -21,7 +21,7 @@ export function ProjectBackgroundMusic({ backgroundMusic }: ProjectBackgroundMus
 	const [autoplayed, setAutoplayed] = useState(false);
 	const [blocked, setBlocked] = useState(false);
 	const [hidden, setHidden] = useState(false);
-	const [muted, setMuted] = useState(true); 
+	const [muted, setMuted] = useState(false); 
 	const [volume, setVolume] = useState(0.125);
 
 	useEffect(() => {

--- a/components/project/experimental/Page.tsx
+++ b/components/project/experimental/Page.tsx
@@ -46,13 +46,13 @@ export function ProjectPage({ guild, project, submissions }: ProjectPageProps) {
 				image={project.ogImage ?? 'https://holoen.fans/img/logo.png'}
 			/>
 
-			{project.backgroundMusic != null && (
-				<ProjectBackgroundMusic backgroundMusic={project.backgroundMusic!}/>
-			)}
-
 			{/* Hypothetically this could label the div with a nonexistant 'theme-'*/}
 			{/* class but CSS just ignores nonexistant classes, so who cares? */}
 			<div className={'theme-' + GUILD_TO_OSHI[guild._id!]}>
+				{project.backgroundMusic != null && (
+					<ProjectBackgroundMusic backgroundMusic={project.backgroundMusic!}/>
+				)}
+
 				<div className='flex flex-col h-full min-h-screen bg-skin-background-1 dark:bg-skin-dark-background-1'>
 					{!project.flags?.includes('disableNavbar') && (<Navbar disableHead/>)}
 					{!project.flags?.includes('disableHeader') && (

--- a/components/project/experimental/Page.tsx
+++ b/components/project/experimental/Page.tsx
@@ -38,19 +38,10 @@ export interface ProjectPageProps {
 }
 
 export function ProjectPage({ guild, project, submissions }: ProjectPageProps) {
-	const { darkMode, toggleDarkMode } = useContext(DarkModeContext);
+	const { setDarkMode } = useContext(DarkModeContext);
 
-	if (project.flags?.includes('alwaysDarkMode')) {
-		if (!darkMode) {
-			toggleDarkMode();
-		}
-	}
-
-	if (project.flags?.includes('alwaysLightMode')) {
-		if (darkMode) {
-			toggleDarkMode();
-		}
-	}
+	if (project.flags?.includes('alwaysDarkMode')) setDarkMode(true);
+	if (project.flags?.includes('alwaysLightMode')) setDarkMode(false);
 
 	return (
 		<>

--- a/components/project/experimental/Page.tsx
+++ b/components/project/experimental/Page.tsx
@@ -1,4 +1,6 @@
+import { useContext } from 'react';
 
+import DarkModeContext from '../../../contexts/DarkModeContext';
 import Footer from '../../Footer';
 import Head from '../../Head';
 import Header from '../../Header';
@@ -36,6 +38,20 @@ export interface ProjectPageProps {
 }
 
 export function ProjectPage({ guild, project, submissions }: ProjectPageProps) {
+	const { darkMode, toggleDarkMode } = useContext(DarkModeContext);
+
+	if (project.flags?.includes('alwaysDarkMode')) {
+		if (!darkMode) {
+			toggleDarkMode();
+		}
+	}
+
+	if (project.flags?.includes('alwaysLightMode')) {
+		if (darkMode) {
+			toggleDarkMode();
+		}
+	}
+
 	return (
 		<>
 			<Head

--- a/contexts/DarkModeContext.tsx
+++ b/contexts/DarkModeContext.tsx
@@ -2,6 +2,9 @@ import React from 'react';
 
 const DarkModeContext = React.createContext({
 	darkMode: false,
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	setDarkMode: (darkMode: boolean) => {},
+	saveDarkMode: () => {},
 	toggleDarkMode: () => {},
 });
 export default DarkModeContext;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -21,10 +21,9 @@ function MyApp({ Component, pageProps }: AppProps) {
 
 	const context = {
 		darkMode,
-		toggleDarkMode: () => {
-			window.localStorage.setItem('darkMode', JSON.stringify(!darkMode));
-			setDarkMode(!darkMode);
-		},
+		setDarkMode,
+		saveDarkMode: () => window.localStorage.setItem('darkMode', JSON.stringify(darkMode)),
+		toggleDarkMode: () => setDarkMode(!darkMode),
 	};
 
 	return (


### PR DESCRIPTION
- allows projects to always use dark/light mode with the `alwaysDarkMode` and `alwaysLightMode` flags.
- themes the temporary materialui music controller.
- makes the temporary materialui music controller autoplay properly if the browser is being an ass.