### PR TITLE
fix(dotenv): update CMS public url env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-CMS_URL= # URL to the CMS
+NEXT_PUBLIC_CMS_URL= # URL to the CMS
 REVALIDATE_SECRET= # Secret the CMS can use to revalidate pages
 PAYLOAD_BYPASS_RATE_LIMIT_KEY= # Secret to bypass CMS rate limits
 IMAGINARY_URL=


### PR DESCRIPTION
The appDir now uses `NEXT_PUBLIC_CMS_URL` instead of `CMS_URL`.